### PR TITLE
don't verify SSL certificates of css files

### DIFF
--- a/inlinestyler/converter.py
+++ b/inlinestyler/converter.py
@@ -35,7 +35,9 @@ class Conversion(object):
                         parsed_url = urlparse.urlparse(sourceURL)
                         csspath = urlparse.urljoin(parsed_url.scheme + "://" + parsed_url.hostname, csspath)
 
-                css_content = requests.get(csspath).text
+                # Get css file. Don't verify SSL certificates. It's just a css.
+                # Cloudfront does not have correct SSL certificate and it fails.
+                css_content = requests.get(csspath, verify=False).text
                 aggregate_css += ''.join(css_content)
 
                 element.getparent().remove(element)


### PR DESCRIPTION
Amazone CDN: CloudFront fails.
To reproduce the problem try this:
>>> import requests
>>> requests.get('https://d2fd5orah3cbsb.cloudfront.net/CACHE/css/86199a1a6687.css')
...
SSLError: [Errno 1] _ssl.c:510: error:14090086:SSL routines:SSL3_GET_SERVER_CERTIFICATE:certificate verify failed
>>> requests.get('https://d2fd5orah3cbsb.cloudfront.net/CACHE/css/86199a1a6687.css', verify=False)
<Response [200]>

Please merge it and make a new release on PYPI. Thank you for your effort. This lib is great.