### PR TITLE
Change ElementTree to emit HTML, not XML

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,5 +9,9 @@ install:
 #  - python -c "from lxml import etree; print etree.LIBXSLT_COMPILED_VERSION; print etree.LIBXSLT_VERSION; print etree.LIBXML_VERSION"
   - make init
 
+cache:
+  directories:
+    - $HOME/.cache/pip
 
 script:  make test
+sudo: false

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,8 @@
+0.2.2
+=====
+
+* Changing ElementTree to emit HTML, and not XML (thanks @crimsoncow)
+
 0.2.1
 =====
 

--- a/inlinestyler/__init__.py
+++ b/inlinestyler/__init__.py
@@ -1,2 +1,2 @@
-VERSION = (0, 2, 1)
+VERSION = (0, 2, 2)
 __version__ = '.'.join(map(str, VERSION))

--- a/inlinestyler/converter.py
+++ b/inlinestyler/converter.py
@@ -19,10 +19,10 @@ class Conversion(object):
         self.CSSErrors = []
         self.CSSUnsupportErrors = dict()
         self.supportPercentage = 100
-        self.convertedHTML = ""
+        self.convertedHTML = u""
 
     def perform(self, document, sourceHTML, sourceURL, encoding=None):
-        aggregate_css = ""
+        aggregate_css = u""
 
         # Retrieve CSS rel links from html pasted and aggregate into one string
         CSSRelSelector = CSSSelector("link[rel=stylesheet],link[rel=StyleSheet],link[rel=STYLESHEET]")
@@ -59,8 +59,7 @@ class Conversion(object):
                 v = style.getCssText(separator=u'')
                 element.set('style', v)
 
-        self.convertedHTML = etree.tostring(document, method="xml", pretty_print=True, encoding=encoding)
-        self.convertedHTML = self.convertedHTML.decode(encoding).replace('&#13;', '')  # Tedious raw conversion of line breaks.
+        self.convertedHTML = etree.tostring(document, method="html", pretty_print=True).encode(encoding)
         return self
 
     def styleattribute(self, element):

--- a/test_inlinestyler.py
+++ b/test_inlinestyler.py
@@ -2,13 +2,13 @@ from inlinestyler.utils import inline_css
 
 def test_no_markup():
     inlined = inline_css("Hello World!")
-    expected = u'<html>\n  <body>\n    <p>Hello World!</p>\n  </body>\n</html>\n'
+    expected = u'<html><body><p>Hello World!</p></body></html>\n'
 
     assert expected == inlined
 
-def test_non_utf8_encoding_adds_headers():
-    inlined = inline_css("Hello World!", encoding='utf-16')
-    expected = u"<?xml version='1.0' encoding='utf-16'?>\n<html>\n  <body>\n    <p>Hello World!</p>\n  </body>\n</html>\n"
+def test_respects_encoding_argument():
+    inlined = inline_css(u"Hello World!", encoding='utf-16')
+    expected = u'<html><body><p>Hello World!</p></body></html>\n'.encode('utf-16')
 
     assert expected == inlined
 
@@ -30,11 +30,12 @@ def test_inline_css_in_head():
     """
 
     expected = """<html>
-  <head/>
-  <body>
+        <head>
+            </head>
+        <body>
             Hello <span class="emphasis" style="font-weight: bold">World</span>!
         </body>
-</html>
+    </html>
 """
-
-    assert expected == inline_css(document)
+    inlined = inline_css(document)
+    assert expected == inlined

--- a/test_inlinestyler.py
+++ b/test_inlinestyler.py
@@ -30,12 +30,11 @@ def test_inline_css_in_head():
     """
 
     expected = """<html>
-        <head>
-            </head>
-        <body>
+<head></head>
+<body>
             Hello <span class="emphasis" style="font-weight: bold">World</span>!
         </body>
-    </html>
+</html>
 """
     inlined = inline_css(document)
     assert expected == inlined


### PR DESCRIPTION
When certain tags are self-closing (as setting XML is wont to do),
GMail considers the entire HTML as invalid, and won't display
any of it. Having ETree emit HTML removes this behaviour, and
is what we're trying to do here anyways.

Fixes #9.