### PR TITLE
Fix indentation on tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: python
 
 python:
-  - "2.6"
   - "2.7"
   - "3.4"
   - "3.6"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,15 +1,12 @@
 language: python
 
 python:
+  - "2.6"
   - "2.7"
   - "3.4"
-  - "3.2"
-  - "2.6"
+  - "3.6"
 
 install:
-# This gets the right libxslt installed, but then lxml doesn't use it
-#  - wget http://xmlsoft.org/sources/libxslt-1.1.28.tar.gz; tar xf libxslt-1.1.28.tar.gz; pushd libxslt-1.1.28; CFLAGS="-O0" ./configure && make && sudo make install; popd
-#  - python -c "from lxml import etree; print etree.LIBXSLT_COMPILED_VERSION; print etree.LIBXSLT_VERSION; print etree.LIBXML_VERSION"
   - pip install -U pip wheel
   - make init
 

--- a/test_inlinestyler.py
+++ b/test_inlinestyler.py
@@ -33,11 +33,12 @@ def test_inline_css_in_head():
     """
 
     expected = """<html>
-<head></head>
-<body>
+        <head>
+            </head>
+        <body>
             Hello <span class="emphasis" style="font-weight: bold">World</span>!
         </body>
-</html>
+    </html>
 """
     inlined = inline_css(document)
     assert expected == inlined


### PR DESCRIPTION
This has always been finicky, and depends on the exact version of lxml being used. Since it's semantically the same, we update the test to pass on Travis for ease of development.